### PR TITLE
Fixed ascii/unicode bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Tested on CPython 2.7-3.6 as well as PyPy & PyPy3 -- see Travis-CI link above.
 Rough benchmarks on my machine (mid-2014 Macbook Pro, 2.8GHz i7) using `setup.py
 bench` (which times the creation of 1 million cuids):
 
-Version | us / cuid
+Version | ns / cuid
 --------|----------
-CPython 3.6 | 11.368
-CPython 3.5 | 9.834
-CPython 3.4 | 9.665
-CPython 2.7 | 8.869
-PyPy 5.6.0 | 0.508
+CPython 3.6 | 11368
+CPython 3.5 | 9834
+CPython 3.4 | 9665
+CPython 2.7 | 8869
+PyPy 5.6.0 | 508
 
 _(Note that timing the creation of fewer IDs changes the way PyPy runs the code, because of JIT warmup --
 obviously creating this many IDs takes advantage of the warmed JIT)_

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested on CPython 2.7-3.6 as well as PyPy & PyPy3 -- see Travis-CI link above.
 Rough benchmarks on my machine (mid-2014 Macbook Pro, 2.8GHz i7) using `setup.py
 bench` (which times the creation of 1 million cuids):
 
-Version | μs / cuid
+Version | us / cuid
 --------|----------
 CPython 3.6 | 11.368
 CPython 3.5 | 9.834


### PR DESCRIPTION
Hi necaris,

This is a bug report and I feel like it's good to have my fix.

# problem
the `μs` in README.md is a non ascii character which leads to failing to `pip install cuid.py` . You can refer to the sample bash output below

# possible solution
changed non ascii char `μs` to ascii char `us`



```
(py36) [lizy004@cnsz92pl00191 cuid-0.3]$python setup.py install
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    README = r.read()
  File "/home/lizy004/py36/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 591: ordinal not in range(128)

(py36) [lizy004@cnsz92pl00191 cuid-0.3]$python --version
Python 3.6.8

(py36) [lizy004@cnsz92pl00191 cuid-0.3]$locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.UTF8
LC_CTYPE=UTF-8
LC_NUMERIC="en_US.UTF8"
LC_TIME="en_US.UTF8"
LC_COLLATE="en_US.UTF8"
LC_MONETARY="en_US.UTF8"
LC_MESSAGES="en_US.UTF8"
LC_PAPER="en_US.UTF8"
LC_NAME="en_US.UTF8"
LC_ADDRESS="en_US.UTF8"
LC_TELEPHONE="en_US.UTF8"
LC_MEASUREMENT="en_US.UTF8"
LC_IDENTIFICATION="en_US.UTF8"
LC_ALL=
```